### PR TITLE
Handle PKCS#12 files with empty integrity password

### DIFF
--- a/src/Crypto/Store/PKCS5/PBES1.hs
+++ b/src/Crypto/Store/PKCS5/PBES1.hs
@@ -90,8 +90,10 @@ rc4Combine key = Right . snd . RC4.combine (RC4.initialize key)
 -- | Conversion to UCS2 from UTF-8, ignoring non-BMP bits.
 toUCS2 :: (ByteArrayAccess butf8, ByteArray bucs2) => butf8 -> Maybe bucs2
 toUCS2 pwdUTF8
-    | B.null r  = Just pwdUCS2
-    | otherwise = Nothing
+    | B.null pwdUTF8  = Just $ B.empty -- per RFC 7292 B.2 step 3
+                                       -- "Note that if the password is the empty string, then so is P"
+    | B.null r        = Just pwdUCS2
+    | otherwise       = Nothing
   where
     (p, _, r) = S.fromBytes S.UTF8 $ B.snoc (B.convert pwdUTF8) 0
     pwdBlock  = fromList $ map ucs2 $ toList p :: Block (BE Word16)


### PR DESCRIPTION
The code to convert UTF-8 to UCS-2 was converting the empty string "" in
UTF-8 to "\NUL\NUL" in UCS-2. This caused downstream problems later in
deriving the key from said password.

This deals with section B.2 step #3

https://datatracker.ietf.org/doc/html/rfc7292#appendix-B

To test the problem create a sample file with an empty integrity password sample.p12

```haskell
> Right p12 <- readP12File './sample.p12'
> recover "" p12
Left BadContentMac
```